### PR TITLE
Change tagging to match dd-agent release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    DOCKER_DD_AGENT_VERSION: 5.10.1.1
+    DOCKER_DD_AGENT_VERSION: 11.0.5131
   services:
     - docker
 
@@ -23,5 +23,5 @@ deployment:
     branch: master
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker tag -f `docker images | grep -E 'unifio/docker-dd-agent' | awk '{print $3}'` unifio/docker-dd-agent:${DOCKER_DD_AGENT_VERSION}
+      - docker tag -f `docker images | grep -E 'unifio/docker-dd-agent' | awk '{print $3}'` unifio/docker-dd-agent:${DOCKER_DD_AGENT_VERSION}.${CIRCLE_BUILD_NUM}
       - docker push unifio/docker-dd-agent


### PR DESCRIPTION
- Change tagging to use dd-agent release and append circle build number to avoid overwriting tags.