### PR TITLE
Added consul-template support other updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM datadog/docker-dd-agent
 MAINTAINER Unif.io, Inc. <support@unif.io>
 
 LABEL DATADOG_VERSION="11.0.5131"
-LABEL CONSUL_VERSION="0.8.1"
-LABEL CONSULTEMPLATE_VERSION="0.18.2"
+LABEL CONSUL_VERSION="0.8.3"
+LABEL CONSULTEMPLATE_VERSION="0.18.3"
 
-ENV CONSUL_VERSION=0.8.1
-ENV CONSULTEMPLATE_VERSION=0.18.2
+ENV CONSUL_VERSION=0.8.3
+ENV CONSULTEMPLATE_VERSION=0.18.3
 
 RUN apt-get update && \
     apt-get -y install curl unzip && \
@@ -15,10 +15,16 @@ RUN apt-get update && \
     curl -s --output consul_${CONSUL_VERSION}_linux_amd64.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
     curl -s --output consul_${CONSUL_VERSION}_SHA256SUMS https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS && \
     curl -s --output consul_${CONSUL_VERSION}_SHA256SUMS.sig https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS.sig && \
+    curl -s --output consul-template_${CONSULTEMPLATE_VERSION}_linux_amd64.zip https://releases.hashicorp.com/consul-template/${CONSULTEMPLATE_VERSION}/consul-template_${CONSULTEMPLATE_VERSION}_linux_amd64.zip && \
+    curl -s --output consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS https://releases.hashicorp.com/consul-template/${CONSULTEMPLATE_VERSION}/consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS && \
+    curl -s --output consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS.sig https://releases.hashicorp.com/consul-template/${CONSULTEMPLATE_VERSION}/consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS.sig && \
     gpg --keyserver keys.gnupg.net --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     gpg --batch --verify consul_${CONSUL_VERSION}_SHA256SUMS.sig consul_${CONSUL_VERSION}_SHA256SUMS && \
+    gpg --batch --verify consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS.sig consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS && \
     grep consul_${CONSUL_VERSION}_linux_amd64.zip consul_${CONSUL_VERSION}_SHA256SUMS | sha256sum -c && \
+    grep consul-template_${CONSULTEMPLATE_VERSION}_linux_amd64.zip consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip -d /usr/local/bin consul_${CONSUL_VERSION}_linux_amd64.zip && \
+    unzip -d /usr/local/bin consul-template_${CONSULTEMPLATE_VERSION}_linux_amd64.zip && \
     cd /tmp && \
     rm -rf /tmp/build
 


### PR DESCRIPTION
- Updated consul-template version and consul version added to container.
- Added additional environment variables to support obtaining consul_http_addr from aws metadata and one for consul-dc to be provided for use in obtaining integrations.
- Updated readme to provide added features.
- Process all downloaded integrations with consul-template allowing for the use of GO TEMPLATE syntax for sensitive and dynamic values in integrations.
- Replaced all tabs with spaces when I noticed some had slipped through.