### PR TITLE
Add ability to set procfs_path in datadog.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Some configuration parameters can be changed with environment variables:
 * `CONSUL_HTTP_ADDR` sets the consul server address the default is `127.0.0.1:8500`.
 * `DD_HOSTNAME` set the hostname (write it in `datadog.conf`)
 * `TAGS` set host tags. Add `-e TAGS=simple-tag-0,tag-key-1:tag-value-1` to use [simple-tag-0, tag-key-1:tag-value-1] as host tags.
+* `DD_PROCFS_PATH` set procfs_path in the datadog.conf to enable process integration from container reading host process. Add `-e DD_PROCFS_PATH=/host/proc` to enable monitoring of host process from container when process integration enabled. See [process.yaml.example](https://github.com/DataDog/integrations-core/blob/master/process/conf.yaml.example) on how to configure process integration. Also ensure you have mounted the host proc in the container /host/proc.
 * `EC2_TAGS` set EC2 host tags. Add `-e EC2_TAGS=yes` to use EC2 custom host tags. Requires an [IAM role](https://github.com/DataDog/dd-agent/wiki/Capturing-EC2-tags-at-startup) associated with the instance.
 * `LOG_LEVEL` set logging verbosity (CRITICAL, ERROR, WARNING, INFO, DEBUG). Add `-e LOG_LEVEL=DEBUG` to turn logs to debug mode.
 * `PROXY_HOST`, `PROXY_PORT`, `PROXY_USER` and `PROXY_PASSWORD` set the proxy configuration.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,10 @@ if [[ $DD_HOSTNAME ]]; then
   sed -i -r -e "s/^# ?hostname.*$/hostname: ${DD_HOSTNAME}/" /etc/dd-agent/datadog.conf
 fi
 
+if [[ $DD_PROCFS_PATH ]]; then
+  sed -i -e 's|^# procfs_path.*$|procfs_path: '"${DD_PROCFS_PATH}"'|' /etc/dd-agent/datadog.conf
+fi
+
 if [[ $DD_TAGS ]]; then
   export TAGS=${DD_TAGS}
 fi


### PR DESCRIPTION
- Added environment variable for specifying the host proc path to the container for use in monitoring host level processes from the datadog container.
- Updated readme to reflect new environment variable support.