### PR TITLE
Allow overriding Hostname to socket-hostname in v6

### DIFF
--- a/v6agent/entrypoint/90-consul-configs.sh
+++ b/v6agent/entrypoint/90-consul-configs.sh
@@ -20,7 +20,8 @@ if [[ ${CONSUL_PREFIX} && ${ENABLE_INTEGRATIONS} ]]; then
   fi
 fi
 
-# Enable logs
-if [[ $DD_ENABLE_LOGS ]]; then
-  echo -e "\n# Logs\nlog_enabled: true" | tee -a /etc/datadog-agent/datadog.yaml
+# Enable Forcing ECS Hostname
+if [[ $DD_ECS_SET_HOSTNAME ]]; then
+  SOCKET_HOSTNAME_FQDN=$(hostname -s)
+  echo -e "\n# Force Hostnamae\nhostname: ${SOCKET_HOSTNAME_FQDN}" | tee -a /etc/datadog-agent/datadog.yaml
 fi


### PR DESCRIPTION
* Added environment variable check and when set will override the hostname in the docker container.